### PR TITLE
fix: make argosScreenshot options param optional

### DIFF
--- a/support.d.ts
+++ b/support.d.ts
@@ -10,7 +10,7 @@ declare namespace Cypress {
      */
     argosScreenshot: (
       name: string,
-      options: Partial<Loggable & Timeoutable & ScreenshotOptions>
+      options?: Partial<Loggable & Timeoutable & ScreenshotOptions>
     ) => Chainable<null>;
   }
 }


### PR DESCRIPTION
## Description

Adds an optional `?` mark to the `argosScreenshot()` `options` parameter.

## Type of changes

`enhancement`

## Checklist

Valid all before asking for a code review to `argos-ci/code` :

- [x] I have read the CONTRIBUTING doc
- [x] The commits message follows the [Conventional Commits' policy](https://www.conventionalcommits.org/)
- [x] Lint and unit tests pass locally
- [x] I have added tests if needed

Optional checks:

- [ ] My changes requires a change to the documentation
- [ ] I have updated the documentation accordingly

## Further comments

According to the documentation, we can use the following function to take screenshots `cy.argosScreenshot("home");`
But when you use it within a typescript file, you got an error because the `options` parameter is not optional.

It should have the same signature as the `cy.screenshot()` function -> https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts#L1733
